### PR TITLE
ci: запускать pytest в CI, починить отставшие тесты и pytest.ini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       env:
         PYTHONIOENCODING: utf-8
 
+    - name: Tests
+      run: |
+        pytest
+      env:
+        PYTHONIOENCODING: utf-8
+
 # Прежний job `build` удалён: он ничего не собирал (реальный билд закомментирован),
 # только ставил pyinstaller, а macos-раннер давал разовые инфра-сбои (Failed to load
 # action manifest) → ложные «упавшие» письма. Сборка инсталляторов — локально

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,18 @@
-[tool:pytest]
+; Секция должна называться [pytest]: [tool:pytest] — это формат setup.cfg,
+; в pytest.ini он молча игнорируется вместе со всем конфигом ниже (из-за чего
+; сбор тестов уходил в корень репозитория и цеплял test_connection.py с
+; реальными обращениями в сеть).
+;
+; cov-fail-under = фактическое покрытие на момент включения конфига (34.54%),
+; а не цель. Работает как трещотка: не даёт покрытию падать. Поднимайте по мере
+; появления тестов — прежние 80% не проверялись вообще, потому что весь этот
+; конфиг не читался.
+[pytest]
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = 
+addopts =
     -v
     --tb=short
     --strict-markers
@@ -11,7 +20,7 @@ addopts =
     --cov=app
     --cov-report=term-missing
     --cov-report=html:htmlcov
-    --cov-fail-under=80
+    --cov-fail-under=34
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests as integration tests

--- a/tests/test_services/test_ssh_service.py
+++ b/tests/test_services/test_ssh_service.py
@@ -26,32 +26,38 @@ class TestSSHService:
         # Проверки
         assert service.client == mock_client
         mock_client.set_missing_host_key_policy.assert_called_once()
-        mock_client.connect.assert_called_once_with(
-            hostname='localhost',
-            username='testuser',
-            password='testpass',
-            key_filename=None,
-            port=22,
-            timeout=10
-        )
-    
+        mock_client.connect.assert_called_once()
+
+        # Проверяем значимые параметры, а не полную сигнатуру вызова: точные
+        # значения таймаутов — деталь реализации, их подкрутка не должна ронять тест.
+        kwargs = mock_client.connect.call_args.kwargs
+        assert kwargs['hostname'] == 'localhost'
+        assert kwargs['username'] == 'testuser'
+        assert kwargs['password'] == 'testpass'
+        assert kwargs['key_filename'] is None
+        assert kwargs['port'] == 22
+        assert kwargs['timeout'] > 0
+        # Подключение не должно втихую подхватывать ключи из ~/.ssh или ssh-agent
+        assert kwargs['look_for_keys'] is False
+        assert kwargs['allow_agent'] is False
+
     @patch('app.services.ssh_service.paramiko.SSHClient')
     def test_connect_with_key_file(self, mock_ssh_client):
         """Тест подключения с ключом"""
         mock_client = Mock()
         mock_ssh_client.return_value = mock_client
-        
+
         service = SSHService()
         service.connect('localhost', 'testuser', key_filename='/path/to/key')
-        
-        mock_client.connect.assert_called_once_with(
-            hostname='localhost',
-            username='testuser',
-            password=None,
-            key_filename='/path/to/key',
-            port=22,
-            timeout=10
-        )
+
+        mock_client.connect.assert_called_once()
+
+        kwargs = mock_client.connect.call_args.kwargs
+        assert kwargs['hostname'] == 'localhost'
+        assert kwargs['username'] == 'testuser'
+        assert kwargs['password'] is None
+        assert kwargs['key_filename'] == '/path/to/key'
+        assert kwargs['port'] == 22
     
     @patch('app.services.ssh_service.paramiko.SSHClient')
     def test_connect_authentication_error(self, mock_ssh_client):
@@ -85,15 +91,18 @@ class TestSSHService:
         """Тест отключения"""
         service = SSHService()
         
-        # Мокаем клиентов
-        service.sftp_client = Mock()
-        service.client = Mock()
-        
+        # Мокаем клиентов. Ссылки держим локально: disconnect() обнуляет атрибуты,
+        # поэтому проверять вызовы через service.* после него уже нельзя.
+        mock_sftp = Mock()
+        mock_client = Mock()
+        service.sftp_client = mock_sftp
+        service.client = mock_client
+
         service.disconnect()
-        
+
         # Проверяем, что клиенты закрыты
-        service.sftp_client.close.assert_called_once()
-        service.client.close.assert_called_once()
+        mock_sftp.close.assert_called_once()
+        mock_client.close.assert_called_once()
         assert service.sftp_client is None
         assert service.client is None
     
@@ -158,10 +167,12 @@ class TestSSHService:
         """Тест загрузки файла"""
         service = SSHService()
         
-        # Мокаем SFTP клиента
+        # Мокаем SFTP клиента. client тоже нужен: upload_file идёт через
+        # get_sftp_client(), а тот падает с SSHConnectionError без SSH-подключения.
         mock_sftp = Mock()
+        service.client = Mock()
         service.sftp_client = mock_sftp
-        
+
         service.upload_file('/local/path', '/remote/path')
         
         mock_sftp.put.assert_called_once_with('/local/path', '/remote/path')
@@ -172,8 +183,9 @@ class TestSSHService:
         
         # Мокаем SFTP клиента
         mock_sftp = Mock()
+        service.client = Mock()
         service.sftp_client = mock_sftp
-        
+
         service.download_file('/remote/path', '/local/path')
         
         mock_sftp.get.assert_called_once_with('/remote/path', '/local/path')
@@ -191,6 +203,7 @@ class TestSSHService:
         mock_file_attr.st_mtime = 1234567890
         
         mock_sftp.listdir_attr.return_value = [mock_file_attr]
+        service.client = Mock()
         service.sftp_client = mock_sftp
         
         result = service.list_directory('/remote/path')
@@ -279,16 +292,23 @@ class TestSSHService:
             stdout.read.return_value = output.encode('utf-8')
             return stdin, stdout, stderr
 
+        # Матчим по подстроке, а не по точной команде: код детекта утилит уже
+        # переезжал с `which` на `command -v` с явным PATH, и точное сравнение
+        # молча превращало тест в проверку ветки «утилита не установлена».
         def exec_side_effect(command):
-            mapping = {
-                'which vnstat': '/usr/bin/vnstat\n',
-                'which jq': '/usr/bin/jq\n',
-                'which ufw': '/usr/sbin/ufw\n',
-                'which netstat': '/usr/bin/netstat\n',
-                'systemctl is-active vnstat 2>/dev/null': 'active\n',
-                'sudo ufw status 2>/dev/null | grep "Status:" | awk \'{print $2}\'': 'active\n',
-            }
-            return make_result(mapping.get(command, ''))
+            if 'ufw status' in command:
+                return make_result('active\n')
+            if 'systemctl is-active vnstat' in command:
+                return make_result('active\n')
+            for name, path in (
+                ('vnstat', '/usr/bin/vnstat'),
+                ('jq', '/usr/bin/jq'),
+                ('ufw', '/usr/sbin/ufw'),
+                ('netstat', '/usr/bin/netstat'),
+            ):
+                if 'command -v %s ' % name in command:
+                    return make_result('%s\n' % path)
+            return make_result('')
 
         client.exec_command.side_effect = exec_side_effect
 
@@ -301,6 +321,10 @@ class TestSSHService:
             )
 
         ufw_tool = result['tools']['ufw']
+        # Страховка от тихой деградации: если детект утилиты снова разъедется с
+        # моком, тест должен падать здесь, а не проверять не ту ветку кода.
+        assert ufw_tool['installed'] is True
+        assert ufw_tool['enabled'] is True
         assert ufw_tool['warning'] == '⚠️ UFW включен! Убедитесь что SSH-порт 22542 разрешен!'
         assert ufw_tool['fix_cmd'] == 'sudo ufw allow 22542/tcp && sudo ufw status numbered'
 


### PR DESCRIPTION
## 📝 Описание изменений

Три связанные проблемы, из-за которых CI не ловил регрессии вообще.

**1. CI не запускал тесты.** Пайплайн делал только `pip install -r requirements.txt` и `python generate_key.py` — 20 секунд, `pytest` не вызывался ни разу. Зелёная галочка означала «зависимости встали», не более.

**2. `pytest.ini` не читался.** Секция называлась `[tool:pytest]` — это формат для `setup.cfg`; в `pytest.ini` нужна `[pytest]`. Весь конфиг игнорировался молча, без ошибки. Из-за этого не работал `testpaths = tests`, и голый `pytest` собирал тесты из корня репозитория, включая `test_connection.py`, который реально ходит на `8.8.8.8:53` и `google.com` — в CI это был бы флак, зависящий от сети раннера.

**3. Семь тестов в `test_ssh_service.py` лежали сломанными.** Они отстали от кода, а красного сигнала никто не видел — прямое следствие пунктов 1 и 2. Проверил: те же 7 падают и на `main` до этого PR, к правкам здесь отношения не имеют.

Что именно разъехалось:

| Тест | Причина падения |
|---|---|
| `test_connect_success`, `test_connect_with_key_file` | В `connect()` добавились `banner_timeout`, `auth_timeout`, `look_for_keys`, `allow_agent`, а `timeout` вырос с 10 до 30 |
| `test_disconnect` | `disconnect()` обнуляет атрибуты, поэтому `service.sftp_client.close` после вызова падал на `None` |
| `test_upload_file`, `test_download_file`, `test_list_directory` | Идут через `get_sftp_client()`, которому нужен ещё и `self.client`, а тест ставил только `sftp_client` |
| `test_check_required_tools_uses_server_ssh_port_in_ufw_warning` | Детект утилит переехал с `which ufw` на `command -v` с явным PATH; точное сравнение команд перестало матчиться, и тест молча проверял ветку «утилита не установлена» |

Чинил так, чтобы не повторилось: в тестах на `connect()` проверяются значимые аргументы вместо пиннинга всей сигнатуры (подкрутка таймаутов больше не уронит тест, но `look_for_keys=False` и `allow_agent=False` проверяются явно — это поведение, а не деталь). В тесте UFW команды матчатся по подстроке плюс добавлены явные `assert installed/enabled`, чтобы будущая деградация падала громко, а не превращалась в проверку не той ветки.

## 🔧 Тип изменений

- [x] 🐛 Исправление ошибки
- [ ] ✨ Новая функция
- [ ] 📚 Обновление документации
- [ ] 🎨 Улучшение интерфейса
- [ ] ⚡ Оптимизация производительности
- [ ] 🔒 Улучшение безопасности
- [x] 🧪 Добавление тестов
- [ ] 🔧 Рефакторинг кода

## 🧪 Тестирование

- [x] Я протестировал изменения локально
- [x] Я добавил тесты для новых функций
- [x] Все существующие тесты проходят
- [ ] Я проверил совместимость с разными ОС

- `pytest` (через починенный конфиг) → **60 passed**, покрытие 34.54%
- `pytest tests/test_services/test_ssh_service.py` → 23 passed, было 16 passed / 7 failed
- Проверил, что `testpaths` теперь работает: `test_connection.py` из корня и `backup_tools/legacy_backup_*/test_basic.py` больше не собираются

## 📋 Чек-лист

- [x] Мой код соответствует стилю проекта
- [x] Я обновил документацию, если необходимо
- [x] Я добавил комментарии к коду, где это необходимо
- [x] Мои изменения не создают новых предупреждений
- [x] Я добавил тесты, которые доказывают, что мой код работает
- [x] Все новые и существующие тесты проходят

## 📸 Скриншоты (если применимо)

Не применимо.

## 📝 Дополнительные заметки

**Одно решение требует вашего согласия: порог покрытия снижен с 80% до 34%.**

Фактическое покрытие — 34.54%. Прежние 80% в конфиге никогда не проверялись, потому что сам конфиг не читался. Как только конфиг оживает, `--cov-fail-under=80` делает CI постоянно красным. Поставил 34 — это не цель, а трещотка против регресса: покрытию не дадут упасть ниже текущего, а планку можно поднимать по мере появления тестов. Если предпочитаете иначе — можно убрать `--cov-fail-under` совсем или оставить 80 и временно не гейтить сборку.

`test_connection.py` в корне репозитория стоит либо перенести в `tests/` с маркером `integration`, либо удалить: сейчас это скрипт ручной диагностики сети, живущий под именем теста. Не трогал, чтобы не расширять диапазон PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ja3p8VwyQEaqcBB1qHQemU)_