### PR TITLE
fix(desktop): закрывать окно через window.destroy()

### DIFF
--- a/desktop/window.py
+++ b/desktop/window.py
@@ -168,7 +168,10 @@ class DesktopApp:
         """Остановка desktop приложения"""
         try:
             if self.window:
-                webview.destroy_window(self.window)
+                # Не webview.destroy_window(window) — это API pywebview 2.x, его нет
+                # ни в 4.x, ни в 6.x. AttributeError глотался except-ом ниже, и окно
+                # молча оставалось открытым.
+                self.window.destroy()
             logger.info("Desktop app stopped")
         except Exception as e:
             logger.error(f"Error stopping desktop app: {str(e)}")

--- a/tests/test_desktop/test_window.py
+++ b/tests/test_desktop/test_window.py
@@ -1,0 +1,47 @@
+"""Тесты обвязки pywebview.
+
+GUI тут не поднимается — проверяется только то, что код зовёт существующие
+методы pywebview. Именно этого не хватало, когда вызов webview.destroy_window()
+из pywebview 2.x пережил переезд на 4.x и 6.x: AttributeError глотался общим
+except, окно не закрывалось, а тестов на этот путь не было.
+"""
+
+from unittest.mock import Mock
+
+import webview
+
+from desktop.window import DesktopApp
+
+
+def test_stop_destroys_window():
+    app = DesktopApp()
+    app.window = Mock()
+
+    app.stop()
+
+    app.window.destroy.assert_called_once_with()
+
+
+def test_stop_without_window_does_not_raise():
+    app = DesktopApp()
+    assert app.window is None
+
+    app.stop()  # не должно бросать
+
+
+def test_stop_swallows_destroy_errors():
+    """Ошибка закрытия не должна ронять выход из приложения."""
+    app = DesktopApp()
+    app.window = Mock()
+    app.window.destroy.side_effect = RuntimeError('window already gone')
+
+    app.stop()
+
+
+def test_legacy_destroy_window_api_is_gone():
+    """Фиксируем причину бага: функции webview.destroy_window больше не существует.
+
+    Если она когда-нибудь вернётся в pywebview, тест напомнит пересмотреть
+    комментарий в DesktopApp.stop().
+    """
+    assert not hasattr(webview, 'destroy_window')


### PR DESCRIPTION
## 📝 Описание изменений

`DesktopApp.stop()` вызывал `webview.destroy_window(self.window)` — это API pywebview **2.x**. Такой функции нет ни в 4.x, ни в 6.x, проверил обе версии:

```
pywebview 4.4.1 — has destroy_window: False
pywebview 6.2.1 — has destroy_window: False
```

Вызов бросал `AttributeError`, который проглатывался общим `except Exception` в том же методе. Наружу это выглядело как «приложение не закрывается», а в лог падало:

```
ERROR desktop.window:window.py:174 Error stopping desktop app: module 'webview' has no attribute 'destroy_window'
```

Заменено на `self.window.destroy()` — актуальный вызов, который уже используется в `app/routes/api.py:1932` при закрытии из интерфейса. Баг латентный и от версии pywebview не зависел, нашёлся при разборе совместимости для #34.

## 🔧 Тип изменений

- [x] 🐛 Исправление ошибки
- [ ] ✨ Новая функция
- [ ] 📚 Обновление документации
- [ ] 🎨 Улучшение интерфейса
- [ ] ⚡ Оптимизация производительности
- [ ] 🔒 Улучшение безопасности
- [x] 🧪 Добавление тестов
- [ ] 🔧 Рефакторинг кода

## 🧪 Тестирование

- [x] Я протестировал изменения локально
- [x] Я добавил тесты для новых функций
- [x] Все существующие тесты проходят
- [ ] Я проверил совместимость с разными ОС

Добавлен `tests/test_desktop/test_window.py` — 4 теста на обвязку pywebview. GUI в них не поднимается (в CI это и невозможно), проверяется ровно то, чего не хватало: что код зовёт существующие методы библиотеки.

- `pytest tests/test_desktop/` → 4 passed
- На коде до правки `test_stop_destroys_window` падает, причём в логе теста видно исходную ошибку — то есть тест ловит именно этот баг, а не что-то соседнее
- `pytest tests/` → 57 passed, 7 failed. Все 7 — в `test_ssh_service.py`, предсуществующие, чинятся в #40; здесь не трогал

Проверка ручного сценария закрытия окна на реальной машине остаётся за вами — он есть в чеклисте, который я оставил в #34.

## 📋 Чек-лист

- [x] Мой код соответствует стилю проекта
- [x] Я обновил документацию, если необходимо
- [x] Я добавил комментарии к коду, где это необходимо
- [x] Мои изменения не создают новых предупреждений
- [x] Я добавил тесты, которые доказывают, что мой код работает
- [x] Все новые и существующие тесты проходят

## 📸 Скриншоты (если применимо)

Не применимо.

## 📝 Дополнительные заметки

С #40 не конфликтует — разные файлы. Порядок мержа любой, но после #40 эти тесты начнут реально гоняться в CI, сейчас пайплайн `pytest` ещё не запускает.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ja3p8VwyQEaqcBB1qHQemU)_